### PR TITLE
Remove MANIFEST entries not present in dist

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,7 +1,3 @@
-build/chapters/.gitignore
-build/epub/.gitignore
-build/pdf/.gitignore
-build/xhtml/.gitignore
 build/html/style.css
 build/latex/book.tex
 build/latex/copyright.tex


### PR DESCRIPTION
This fixes the `the following files are missing in your kit` warning
that currently appears when running `perl Makefile.PL`.

If you would rather that I add such entries to a `MANIFEST.SKIP` file, just let me know and I'll make a new PR for that change.